### PR TITLE
fix(STS): Aws::STS::Resource is useless

### DIFF
--- a/lib/thor/aws.rb
+++ b/lib/thor/aws.rb
@@ -112,7 +112,7 @@ module Thor::Aws
     sns:                  Aws::SNS::Resource,
     sqs:                  Aws::SQS::Resource,
     storagegateway:       Aws::StorageGateway::Resource,
-    sts:                  Aws::STS::Resource,
+    sts:                  Aws::STS::Client,
     support:              Aws::Support::Resource,
     swf:                  Aws::SWF::Resource,
   }.each do |name, klass|


### PR DESCRIPTION
`Aws::STS::Resource` dose not have `client` instance.
We must use `Aws::STS::Client` instance.
